### PR TITLE
Add filter to ical calendar to remove old events

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,16 @@ Spring Boot with Spring MVC + Spring Data JPA + Spring Security + Thymeleaf + Po
 
 ## Development
 
-`mvn -DskipTests clean dependency:list install`
-`java -jar target/calypso-1.0-SNAPSHOT.jar`
+1. Configure database connection in `resources/application.properties`.
+```
+spring.datasource.url=jdbc:postgresql://localhost:5432/DB_NAME
+spring.datasource.username=USER
+spring.datasource.password=PSWD
+```
+Do not commit these changes
+
+2. `mvn -DskipTests clean dependency:list install`
+3. `java -jar target/calypso-1.0-SNAPSHOT.jar`
 
 -----------
 
@@ -17,5 +25,8 @@ for development configuration. All config in this file will override the global
 `application.properties`
 
 ## Environment variables
-LOGIN_KEY
-APPLICATION_URL
+
+| Name                         | Description                 | Default                 | Example                                |
+| ---------------------------- | --------------------------- | ----------------------- | -------------------------------------- |
+| LOGIN_KEY                    | Login key                   | ---                     | ---                                    |
+| APPLICATION_URL              | URL to backend              | ---                     | http://localhost.datasektionen.se:8080 |

--- a/src/main/java/se/datasektionen/calypso/feeds/IcalFeed.java
+++ b/src/main/java/se/datasektionen/calypso/feeds/IcalFeed.java
@@ -11,6 +11,8 @@ import se.datasektionen.calypso.models.repositories.ApiRepository;
 
 import static se.datasektionen.calypso.feeds.DateUtils.ldtToDate;
 
+import java.time.LocalDateTime;
+
 @Service
 @RequiredArgsConstructor
 public class IcalFeed {
@@ -30,7 +32,11 @@ public class IcalFeed {
 		apiRepository
 				.allEvents()
 				.stream()
-				.filter(e -> e.getEventStartTime() != null && e.getEventEndTime() != null)
+				.filter(e ->
+					e.getEventStartTime() != null && e.getEventEndTime() != null &&
+					LocalDateTime.now().minusMonths(2)
+					.compareTo(e.getEventStartTime()) < 0
+				)
 				.map(IcalFeed::toEvent)
 				.forEach(ical::addEvent);
 


### PR DESCRIPTION
This filter is added in order to make the calendar less cluttered. Currently, I set it to keep only 2 moths of history of events.
It's kind of annoying to have really old events from years ago. But I still think it might be useful to have events from one to two months ago.