### PR TITLE
Specify vue version

### DIFF
--- a/src/main/resources/templates/edit.html
+++ b/src/main/resources/templates/edit.html
@@ -34,7 +34,7 @@
             spellChecker: false
         });
     </script>
-    <script type="text/javascript" src="https://unpkg.com/vue"></script>
+    <script type="text/javascript" src="https://unpkg.com/vue@2.6.14"></script>
     <script type="text/javascript" th:inline="text">
         var Data = {
             contentType: "[[${item.itemType != null ? item.itemType : 'POST'}]]",

--- a/src/main/resources/templates/reception.html
+++ b/src/main/resources/templates/reception.html
@@ -6,7 +6,7 @@
     <title>Mottagningsläge</title>
     <script type="text/javascript"></script>
     <link rel="stylesheet" href="/css/overrides.css" />
-    <script type="text/javascript" src="https://unpkg.com/vue"></script>
+    <script type="text/javascript" src="https://unpkg.com/vue@2.6.14"></script>
 </head>
 <body>
 


### PR DESCRIPTION
Vue recently bumped the default version of vue to v3. If you check https://unpkg.com/vue
on web archive the 1st of January 2022 you see that it redirects to version https://unpkg.com/vue@2.6.14