### PR TITLE
Implement filter for only your own posts

### DIFF
--- a/src/main/java/se/datasektionen/calypso/controllers/admin/ListController.java
+++ b/src/main/java/se/datasektionen/calypso/controllers/admin/ListController.java
@@ -33,6 +33,7 @@ public class ListController {
 	                    @RequestParam(name = "sortBy", defaultValue = "publishDate") String sortBy,
 	                    @RequestParam(name = "sort", defaultValue = "DESC") String sort,
 	                    @RequestParam(name = "page", defaultValue = "0") int page,
+											@RequestParam(name = "onlyMe", defaultValue = "false") boolean onlyMe,
 	                    Authentication auth, Model model) {
 		// Common objects
 		var type = ItemType.valueOfIgnoreCase(itemType);
@@ -42,12 +43,12 @@ public class ListController {
 
 		// Items
 		if (type == null)
-			if (user.getAuthorities().contains(new SimpleGrantedAuthority("editor")))
+			if (!onlyMe && user.getAuthorities().contains(new SimpleGrantedAuthority("editor")))
 				items = itemRepository.findAll(pageable);
 			else
 				items = itemRepository.findAllByAuthor(user.getUser(), pageable);
 		else
-			if (user.getAuthorities().contains(new SimpleGrantedAuthority("editor")))
+			if (!onlyMe && user.getAuthorities().contains(new SimpleGrantedAuthority("editor")))
 				items = itemRepository.findAllByItemType(type, pageable);
 			else
 				items = itemRepository.findAllByItemTypeAndAuthor(type, user.getUser(), pageable);

--- a/src/main/java/se/datasektionen/calypso/controllers/admin/ListController.java
+++ b/src/main/java/se/datasektionen/calypso/controllers/admin/ListController.java
@@ -39,16 +39,18 @@ public class ListController {
 		var type = ItemType.valueOfIgnoreCase(itemType);
 		var pageable = PageRequest.of(page, PAGE_SIZE, Sort.by(Sort.Direction.valueOf(sort), sortBy));
 		var user = (DAuthUserDetails) auth.getPrincipal();
+		var editor = user.getAuthorities().contains(new SimpleGrantedAuthority("editor"));
 		Page<Item> items;
+
 
 		// Items
 		if (type == null)
-			if (!onlyMe && user.getAuthorities().contains(new SimpleGrantedAuthority("editor")))
+			if (!onlyMe && editor)
 				items = itemRepository.findAll(pageable);
 			else
 				items = itemRepository.findAllByAuthor(user.getUser(), pageable);
 		else
-			if (!onlyMe && user.getAuthorities().contains(new SimpleGrantedAuthority("editor")))
+			if (!onlyMe && editor)
 				items = itemRepository.findAllByItemType(type, pageable);
 			else
 				items = itemRepository.findAllByItemTypeAndAuthor(type, user.getUser(), pageable);
@@ -58,6 +60,7 @@ public class ListController {
 		model.addAttribute("page", page);
 		model.addAttribute("items", items);
 		model.addAttribute("itemType", type);
+		model.addAttribute("onlyMe", onlyMe);
 		return "list";
 	}
 

--- a/src/main/resources/templates/list.html
+++ b/src/main/resources/templates/list.html
@@ -40,15 +40,40 @@
         </div>
 
         <div class="row">
-            <div class="col-sm-6 text-muted" style="padding-top: 5px;">
+            <div class="col-md-8 text-muted" style="padding-top: 5px;">
                 <small th:text="${'Totalt ' + items.totalElements + ' objekt du kan redigera.'}"></small>
             </div>
-            <div class="col-sm-6">
+            <div class="col-md-2 text-muted" style="padding-top: 5px; text-align: right;">
+                <div sec:authorize="hasAuthority('editor')">
+                    <form method="get" name="onlyMeSelector">
+                        <input type="hidden" name="itemType" th:value="${itemType}">
+                        <input type="hidden" name="page" th:value="${page}">
+                        <span  class="checkbox">
+                            <input type="checkbox" name="onlyMe" value="true" id="onlyMe" th:if="${onlyMe}" checked/>
+                            <input type="checkbox" name="onlyMe" value="true" id="onlyMe" th:unless="${onlyMe}"/>
+                            <label for="onlyMe" class="form-label-narrow">Endast dina inlägg</label>
+                        </span>
+                        <script>
+                            document.getElementById("onlyMe").addEventListener('change',
+                                function (event) {
+                                    document.forms["onlyMeSelector"].submit()
+                                });
+                        </script>
+                    </form>
+                </div>
+            </div>
+            <div class="col-md-2">
                 <div class="table-pagination" style="text-align: right !important;">
                     <ul class="pagination pagination-sm" style="margin: 0; margin-bottom: 5px;">
-                        <li th:class="${itemType == null}  ? active : ''"><a th:href="@{${'/admin/list'}}">Alla</a></li>
-                        <li th:class="${itemType != null && itemType.name() == 'EVENT'} ? active : ''"><a th:href="@{${'/admin/list'}(itemType=EVENT)}">Event</a></li>
-                        <li th:class="${itemType != null && itemType.name() == 'POST'}  ? active : ''"><a th:href="@{${'/admin/list'}(itemType=POST)}">Nyheter</a></li>
+                        <li th:class="${itemType == null}  ? active : ''">
+                            <a th:href="@{${'/admin/list'}(onlyMe=${onlyMe}, page=${page})}">Alla</a>
+                        </li>
+                        <li th:class="${itemType != null && itemType.name() == 'EVENT'} ? active : ''">
+                            <a th:href="@{${'/admin/list'}(itemType=EVENT, onlyMe=${onlyMe}, page=${page})}">Event</a>
+                        </li>
+                        <li th:class="${itemType != null && itemType.name() == 'POST'}  ? active : ''">
+                            <a th:href="@{${'/admin/list'}(itemType=POST, onlyMe=${onlyMe}, page=${page})}">Nyheter</a>
+                        </li>
                     </ul>
                 </div>
             </div>
@@ -149,7 +174,7 @@
         <div class="table-pagination" th:if="${items.getTotalElements() > 0}">
             <ul class="pagination">
                 <li th:class="${items.number eq 0} ? 'disabled' : ''">
-                    <a th:unless="${page == 0}" th:href="@{${'/admin/list'}(page=${items.number-1},itemType=${itemType})}">&laquo;</a>
+                    <a th:unless="${page == 0}" th:href="@{${'/admin/list'}(page=${items.number-1},itemType=${itemType},onlyMe=${onlyMe})}">&laquo;</a>
                     <a th:if="${page == 0}" class="disabled" href="javascript:void(0);">&laquo;</a>
                 </li>
 
@@ -157,13 +182,12 @@
                     <a th:if="${items.number == pageNo}" href="javascript:void(0);" class="disabled">
                         <span th:text="${pageNo + 1}"></span>
                     </a>
-                    <a th:unless="${items.number == pageNo}" th:href="@{${'/admin/list'}(page=${pageNo},itemType=${itemType})}">
+                    <a th:unless="${items.number == pageNo}" th:href="@{${'/admin/list'}(page=${pageNo},itemType=${itemType},onlyMe=${onlyMe})}">
                         <span th:text="${pageNo + 1}"></span>
                     </a>
-
                 </li>
                 <li th:class="${items.number + 1 ge items.totalPages} ? 'disabled' : ''">
-                    <a th:unless="${items.isLast()}" th:href="@{${'/admin/list'}(page=${page+1},itemType=${itemType})}">&raquo;</a>
+                    <a th:unless="${items.isLast()}" th:href="@{${'/admin/list'}(page=${page+1},itemType=${itemType},onlyMe=${onlyMe})}">&raquo;</a>
                     <a th:if="${items.isLast()}" href="javascript:void(0);">&raquo;</a>
                 </li>
             </ul>


### PR DESCRIPTION
Adds a checkbox for only viewing your own posts when you are an editor, as well as fix some bugs with disappearing GET parameters

Looks like this: 
![2022-04-06-01:29:33](https://user-images.githubusercontent.com/16057417/161868163-1bdfd3f6-1653-47bd-a618-a76e56fac123.png)
![2022-04-06-01:29:47](https://user-images.githubusercontent.com/16057417/161868176-3d941837-8f60-4cc7-8659-16b08c7bf031.png)

One disadvantage to the bug fixes I did is that the URL looks worse

Tested locally, where seemingly works without problems

Partly implements #29, a search bar could still be nice to have, but I thought that the case for only showing your own posts was useful enough to have a dedicated button for it.