### PR TITLE
fix: only return 404 if reception mode is on and an item is sensitive

### DIFF
--- a/src/main/java/se/datasektionen/calypso/controllers/api/ApiController.java
+++ b/src/main/java/se/datasektionen/calypso/controllers/api/ApiController.java
@@ -71,8 +71,12 @@ public class ApiController {
 	@RequestMapping("/item/{id}")
 	public Item item(@PathVariable("id") long itemId) {
 		Optional<Item> item = apiRepository.findById(itemId);
-		if (item.isPresent() && !receptionRepository.get().getState()) return item.get();
-		else throw new ResourceNotFoundException();
+		if (item.isPresent()) {
+			if (receptionRepository.get().getState()) { // Reception mode is on
+				if (!item.get().isSensitive()) return item.get();
+			} else return item.get();
+		}
+		throw new ResourceNotFoundException();
 	}
 
 }


### PR DESCRIPTION
Fix a bug where when reception mode was on, we returned 404 for all items