### PR TITLE
Display info box in home when reception mode is on

### DIFF
--- a/src/main/java/se/datasektionen/calypso/controllers/admin/ListController.java
+++ b/src/main/java/se/datasektionen/calypso/controllers/admin/ListController.java
@@ -15,6 +15,7 @@ import se.datasektionen.calypso.auth.DAuthUserDetails;
 import se.datasektionen.calypso.models.entities.Item;
 import se.datasektionen.calypso.models.enums.ItemType;
 import se.datasektionen.calypso.models.repositories.ItemRepository;
+import se.datasektionen.calypso.models.repositories.ReceptionRepository;
 
 import java.time.format.DateTimeFormatter;
 
@@ -27,6 +28,7 @@ public class ListController {
 
 	private final ItemRepository itemRepository;
 	private final DateTimeFormatter formatter;
+	private final ReceptionRepository receptionRepository;
 
 	@RequestMapping("/admin/list")
 	public String index(@RequestParam(name = "itemType", required = false) String itemType,
@@ -55,12 +57,17 @@ public class ListController {
 			else
 				items = itemRepository.findAllByItemTypeAndAuthor(type, user.getUser(), pageable);
 
+		boolean receptionMode = receptionRepository.get() == null
+			? false // reception mode not initialized in db, return false
+			: receptionRepository.get().getState(); // get the state
+
 		// Populate model
 		model.addAttribute("formatter", formatter);
 		model.addAttribute("page", page);
 		model.addAttribute("items", items);
 		model.addAttribute("itemType", type);
 		model.addAttribute("onlyMe", onlyMe);
+		model.addAttribute("receptionMode", receptionMode);
 		return "list";
 	}
 

--- a/src/main/resources/templates/list.html
+++ b/src/main/resources/templates/list.html
@@ -39,6 +39,10 @@
             Inlägg med ID #<span th:text="${param.deleted}"></span> raderades.
         </div>
 
+        <div th:if="${receptionMode}">
+            <div class="alert alert-info">Mottagningsläget är för närvarande påslaget. Nyheter markerade som känsliga kommer inte exponeras av APIet eller synas på hemsidan.</div>
+        </div>
+
         <div class="row">
             <div class="col-md-8 text-muted" style="padding-top: 5px;">
                 <small th:text="${'Totalt ' + items.totalElements + ' objekt du kan redigera.'}"></small>


### PR DESCRIPTION
Displays an info box which informs that the reception mode is on.

![image](https://user-images.githubusercontent.com/33149910/180983654-fe18b70d-6a08-4d3d-979f-8b8ce3c4ce35.png)
