### PR TITLE
fix: Fix error message always being empty

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,4 @@ spring.datasource.url=${JDBC_DATABASE_URL}
 spring.datasource.username=${JDBC_DATABASE_USERNAME}
 spring.datasource.password=${JDBC_DATABASE_PASSWORD}
 server.port=${PORT:8080}
+server.error.include-message=ALWAYS


### PR DESCRIPTION
The exception message is now shown properly after "Systemet gav följande meddelande:" on error pages.