### PR TITLE
Better post character limit error messages #77

### DIFF
--- a/src/main/java/se/datasektionen/calypso/models/entities/Activity.java
+++ b/src/main/java/se/datasektionen/calypso/models/entities/Activity.java
@@ -76,12 +76,14 @@ public class Activity implements SecurityTarget {
 
 	@Column(nullable = false, length = 10000)
 	@NotBlank
-	@Size(min = 50, max = 9999, message = "Innehåll (svenska) måste vara minst 50 tecken")
+	@Size(min = 50, message = "Innehåll (svenska) måste vara minst 50 tecken")
+	@Size(max = 9999, message = "Innehåll (svenska) får vara högst 9999 tecken")
 	private String contentSwedish;
 
 	@Column(nullable = false, length = 10000)
 	@NotBlank
-	@Size(min = 50, max = 9999, message = "Innehåll (engelska) måste vara minst 50 tecken")
+	@Size(min = 50, message = "Innehåll (engelska) måste vara minst 50 tecken")
+	@Size(max = 9999, message = "Innehåll (engelska) får vara högst 9999 tecken")
 	private String contentEnglish;
 
 	@OneToMany(mappedBy = "activity", cascade = { CascadeType.ALL })

--- a/src/main/java/se/datasektionen/calypso/models/entities/Activity.java
+++ b/src/main/java/se/datasektionen/calypso/models/entities/Activity.java
@@ -50,11 +50,13 @@ public class Activity implements SecurityTarget {
 	@Column(nullable = false)
 	@NotBlank
 	@Size(min = 8, message = "Titel (svenska) måste vara minst åtta tecken")
+	@Size(max = 255, message = "Titel (svenska) får vara högst 255 tecken")
 	private String titleSwedish;
 
 	@Column(nullable = false)
 	@NotBlank
 	@Size(min = 8, message = "Titel (engelska) måste vara minst åtta tecken")
+	@Size(max = 255, message = "Titel (engelska) får vara högst 255 tecken")
 	private String titleEnglish;
 
 	@Column(nullable = false)

--- a/src/main/java/se/datasektionen/calypso/models/entities/Item.java
+++ b/src/main/java/se/datasektionen/calypso/models/entities/Item.java
@@ -55,11 +55,13 @@ public class Item implements SecurityTarget {
 	@Column(nullable = false)
 	@NotNull
 	@Size(min = 8, message = "Titel (svenska) måste vara minst åtta tecken")
+	@Size(max = 255, message = "Titel (svenska) får vara högst 255 tecken")
 	private String titleSwedish;
 
 	@Column(nullable = false)
 	@NotNull
 	@Size(min = 8, message = "Titel (engelska) måste vara minst åtta tecken")
+	@Size(max = 255, message = "Titel (engelska) får vara högst 255 tecken")
 	private String titleEnglish;
 
 	@Column(nullable = false)

--- a/src/main/java/se/datasektionen/calypso/models/entities/Item.java
+++ b/src/main/java/se/datasektionen/calypso/models/entities/Item.java
@@ -93,12 +93,14 @@ public class Item implements SecurityTarget {
 
 	@Column(nullable = false, length = 10000)
 	@NotNull
-	@Size(min = 50, max = 9999, message = "Innehåll (svenska) måste vara minst 50 tecken")
+	@Size(min = 50, message = "Innehåll (svenska) måste vara minst 50 tecken")
+	@Size(max = 9999, message = "Innehåll (svenska) får vara högst 9999 tecken")
 	private String contentSwedish;
 
 	@Column(nullable = false, length = 10000)
 	@NotNull
-	@Size(min = 50, max = 9999, message = "Innehåll (engelska) måste vara minst 50 tecken")
+	@Size(min = 50, message = "Innehåll (engelska) måste vara minst 50 tecken")
+	@Size(max = 9999, message = "Innehåll (engelska) får vara högst 9999 tecken")
 	private String contentEnglish;
 
 	@Column

--- a/src/main/java/se/datasektionen/calypso/models/entities/Item.java
+++ b/src/main/java/se/datasektionen/calypso/models/entities/Item.java
@@ -104,6 +104,7 @@ public class Item implements SecurityTarget {
 	private String contentEnglish;
 
 	@Column
+    @Size(max = 255, message = "Eventplats får vara högst 255 tecken")
 	private String eventLocation;
 
 	@Column
@@ -113,9 +114,11 @@ public class Item implements SecurityTarget {
 	private LocalDateTime eventEndTime;
 
 	@Column
+    @Size(max = 255, message = "Facebook-URL får vara högst 255 tecken")
 	private String facebookEvent;
 
 	@Column
+    @Size(max = 255, message = "Google-URL får vara högst 255 tecken")
 	private String googleForm;
 
 	@Enumerated(EnumType.STRING)

--- a/src/main/java/se/datasektionen/calypso/models/entities/Item.java
+++ b/src/main/java/se/datasektionen/calypso/models/entities/Item.java
@@ -104,7 +104,7 @@ public class Item implements SecurityTarget {
 	private String contentEnglish;
 
 	@Column
-    @Size(max = 255, message = "Eventplats får vara högst 255 tecken")
+	@Size(max = 255, message = "Eventplats får vara högst 255 tecken")
 	private String eventLocation;
 
 	@Column
@@ -114,11 +114,11 @@ public class Item implements SecurityTarget {
 	private LocalDateTime eventEndTime;
 
 	@Column
-    @Size(max = 255, message = "Facebook-URL får vara högst 255 tecken")
+	@Size(max = 255, message = "Facebook-URL får vara högst 255 tecken")
 	private String facebookEvent;
 
 	@Column
-    @Size(max = 255, message = "Google-URL får vara högst 255 tecken")
+	@Size(max = 255, message = "Google-URL får vara högst 255 tecken")
 	private String googleForm;
 
 	@Enumerated(EnumType.STRING)


### PR DESCRIPTION
Fixes #77, for English and Swedish title, Facebook and Google URLs, event location, and content (though that's max 9999 chars).