### PR TITLE
Add guid to RSS feed

### DIFF
--- a/src/main/java/se/datasektionen/calypso/feeds/rss/RssConverter.java
+++ b/src/main/java/se/datasektionen/calypso/feeds/rss/RssConverter.java
@@ -3,6 +3,7 @@ package se.datasektionen.calypso.feeds.rss;
 import com.rometools.rome.feed.rss.Content;
 import com.rometools.rome.feed.rss.Description;
 import com.rometools.rome.feed.rss.Enclosure;
+import com.rometools.rome.feed.rss.Guid;
 
 import se.datasektionen.calypso.models.entities.Item;
 
@@ -23,6 +24,10 @@ public class RssConverter {
 															 Function<Item, String> linkMapper) {
 		var rssItem = new com.rometools.rome.feed.rss.Item();
 
+		var guid = new Guid();
+		guid.setPermaLink(false);
+		guid.setValue(linkMapper.apply(item));
+
 		var imageEnclosure = new Enclosure();
 		imageEnclosure.setType("image/png");
 		imageEnclosure.setUrl("https://dsekt-assets.s3.amazonaws.com/calypsotest.png"); //meow :3
@@ -37,6 +42,8 @@ public class RssConverter {
 		rssItem.setPubDate(ldtToDate(item.getPublishDate()));
 		rssItem.setLink(linkMapper.apply(item));
 		rssItem.setEnclosures(List.of(imageEnclosure));
+		rssItem.setGuid(guid);
+
 		return rssItem;
 	}
 


### PR DESCRIPTION
Resolves #75 by setting the guid to the feed item's URL (I think, I have not figured out how to test this yet). I was a bit unsure about whether or not the links to `https://datasektionen.se/nyheter/` are permanent or not, so I set `isPermalink` to `false`.